### PR TITLE
Provide a 20.08beta version

### DIFF
--- a/3660248422f4
+++ b/3660248422f4
@@ -1,0 +1,34 @@
+
+# HG changeset patch
+# User ysuenaga
+# Date 1595335093 -32400
+# Node ID 3660248422f43b4d670eda19fa53af3b7bcc8338
+# Parent  09809f3f9fee579b66f233d765de7b495e8ca4e6
+8238380: java.base/unix/native/libjava/childproc.c "multiple definition" link errors with GCC10
+Reviewed-by: stuefe, clanger, rriggs
+Contributed-by: patrick@os.amperecomputing.com
+
+diff -r 09809f3f9fee -r 3660248422f4 src/java.base/unix/native/libjava/childproc.c
+--- a/src/java.base/unix/native/libjava/childproc.c	Thu Jul 16 06:35:01 2020 +0530
++++ b/src/java.base/unix/native/libjava/childproc.c	Tue Jul 21 21:38:13 2020 +0900
+@@ -33,6 +33,7 @@
+ 
+ #include "childproc.h"
+ 
++const char * const *parentPathv;
+ 
+ ssize_t
+ restartableWrite(int fd, const void *buf, size_t count)
+diff -r 09809f3f9fee -r 3660248422f4 src/java.base/unix/native/libjava/childproc.h
+--- a/src/java.base/unix/native/libjava/childproc.h	Thu Jul 16 06:35:01 2020 +0530
++++ b/src/java.base/unix/native/libjava/childproc.h	Tue Jul 21 21:38:13 2020 +0900
+@@ -118,7 +118,7 @@
+  * The cached and split version of the JDK's effective PATH.
+  * (We don't support putenv("PATH=...") in native code)
+  */
+-const char * const *parentPathv;
++extern const char * const *parentPathv;
+ 
+ ssize_t restartableWrite(int fd, const void *buf, size_t count);
+ int restartableDup2(int fd_from, int fd_to);
+

--- a/371bbe373ae0
+++ b/371bbe373ae0
@@ -1,0 +1,35 @@
+
+# HG changeset patch
+# User ysuenaga
+# Date 1595335373 -32400
+# Node ID 371bbe373ae06d6c62878f9048f47d54faf06c8e
+# Parent  39020dd9b75f6fc9cbd26724822bf58a0226da13
+8238388: libj2gss/NativeFunc.o "multiple definition" link errors with GCC10
+Summary: Fixed libj2gss link errors caused by GCC10 default -fno-common
+Reviewed-by: weijun
+
+diff -r 39020dd9b75f -r 371bbe373ae0 src/java.security.jgss/share/native/libj2gss/NativeFunc.c
+--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.c	Tue Jul 21 21:40:40 2020 +0900
++++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.c	Tue Jul 21 21:42:53 2020 +0900
+@@ -27,6 +27,9 @@
+ #include <stdlib.h>
+ #include "NativeFunc.h"
+ 
++/* global GSS function table */
++GSS_FUNCTION_TABLE_PTR ftab;
++
+ /* standard GSS method names (ordering is from mapfile) */
+ static const char RELEASE_NAME[]                = "gss_release_name";
+ static const char IMPORT_NAME[]                 = "gss_import_name";
+diff -r 39020dd9b75f -r 371bbe373ae0 src/java.security.jgss/share/native/libj2gss/NativeFunc.h
+--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.h	Tue Jul 21 21:40:40 2020 +0900
++++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.h	Tue Jul 21 21:42:53 2020 +0900
+@@ -277,6 +277,6 @@
+ typedef GSS_FUNCTION_TABLE *GSS_FUNCTION_TABLE_PTR;
+ 
+ /* global GSS function table */
+-GSS_FUNCTION_TABLE_PTR ftab;
++extern GSS_FUNCTION_TABLE_PTR ftab;
+ 
+ #endif
+

--- a/39020dd9b75f
+++ b/39020dd9b75f
@@ -1,0 +1,50 @@
+
+# HG changeset patch
+# User ysuenaga
+# Date 1595335240 -32400
+# Node ID 39020dd9b75f6fc9cbd26724822bf58a0226da13
+# Parent  3660248422f43b4d670eda19fa53af3b7bcc8338
+8238386: (sctp) jdk.sctp/unix/native/libsctp/SctpNet.c "multiple definition" link errors with GCC10
+Summary: Fixed libsctp link errors caused by GCC10 default -fno-common
+Reviewed-by: chegar
+
+diff -r 3660248422f4 -r 39020dd9b75f src/jdk.sctp/unix/native/libsctp/Sctp.h
+--- a/src/jdk.sctp/unix/native/libsctp/Sctp.h	Tue Jul 21 21:38:13 2020 +0900
++++ b/src/jdk.sctp/unix/native/libsctp/Sctp.h	Tue Jul 21 21:40:40 2020 +0900
+@@ -322,12 +322,12 @@
+ 
+ #endif /* __linux__ */
+ 
+-sctp_getladdrs_func* nio_sctp_getladdrs;
+-sctp_freeladdrs_func* nio_sctp_freeladdrs;
+-sctp_getpaddrs_func* nio_sctp_getpaddrs;
+-sctp_freepaddrs_func* nio_sctp_freepaddrs;
+-sctp_bindx_func* nio_sctp_bindx;
+-sctp_peeloff_func* nio_sctp_peeloff;
++extern sctp_getladdrs_func* nio_sctp_getladdrs;
++extern sctp_freeladdrs_func* nio_sctp_freeladdrs;
++extern sctp_getpaddrs_func* nio_sctp_getpaddrs;
++extern sctp_freepaddrs_func* nio_sctp_freepaddrs;
++extern sctp_bindx_func* nio_sctp_bindx;
++extern sctp_peeloff_func* nio_sctp_peeloff;
+ 
+ jboolean loadSocketExtensionFuncs(JNIEnv* env);
+ 
+diff -r 3660248422f4 -r 39020dd9b75f src/jdk.sctp/unix/native/libsctp/SctpNet.c
+--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c	Tue Jul 21 21:38:13 2020 +0900
++++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c	Tue Jul 21 21:40:40 2020 +0900
+@@ -43,6 +43,13 @@
+ static const char* nativeSctpLib = "libsctp.so.1";
+ static jboolean funcsLoaded = JNI_FALSE;
+ 
++sctp_getladdrs_func* nio_sctp_getladdrs;
++sctp_freeladdrs_func* nio_sctp_freeladdrs;
++sctp_getpaddrs_func* nio_sctp_getpaddrs;
++sctp_freepaddrs_func* nio_sctp_freepaddrs;
++sctp_bindx_func* nio_sctp_bindx;
++sctp_peeloff_func* nio_sctp_peeloff;
++
+ JNIEXPORT jint JNICALL DEF_JNI_OnLoad
+   (JavaVM *vm, void *reserved) {
+     return JNI_VERSION_1_2;
+

--- a/org.freedesktop.Sdk.Extension.openjdk11.json
+++ b/org.freedesktop.Sdk.Extension.openjdk11.json
@@ -1,8 +1,8 @@
 {
     "id": "org.freedesktop.Sdk.Extension.openjdk11",
-    "branch": "19.08",
+    "branch": "20.08beta",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08beta",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
     "separate-locales": false,
@@ -115,6 +115,18 @@
                     "commands": [
                         "chmod a+x configure"
                     ]
+                },
+                {
+                    "type": "patch",
+                    "path": "3660248422f4"
+                },
+                {
+                    "type": "patch",
+                    "path": "39020dd9b75f"
+                },
+                {
+                    "type": "patch",
+                    "path": "371bbe373ae0"
                 }
             ]
         },


### PR DESCRIPTION
See <https://lists.freedesktop.org/archives/flatpak/2020-August/002019.html> "Freedesktop SDK 20.08 release candidate 1" for the corresponding SDK version.

(The target for this would apparently be some new branch/20.08beta, but it seems not to be possible to directly express that with a GitHub PR.)