### PR TITLE
Allow AWT Desktop class to launch urls and files

### DIFF
--- a/java_desktop_xdg_open.patch
+++ b/java_desktop_xdg_open.patch
@@ -1,0 +1,50 @@
+--- a/src/java.desktop/unix/classes/sun/awt/X11/XDesktopPeer.java	2021-01-16 18:10:28.246735459 -0400
++++ b/src/java.desktop/unix/classes/sun/awt/X11/XDesktopPeer.java	2021-01-16 22:12:54.371818460 -0400
+@@ -59,8 +59,7 @@
+         XToolkit.awtLock();
+         try {
+             if (!initExecuted) {
+-                nativeLibraryLoaded = init(UNIXToolkit.getEnabledGtkVersion()
+-                        .getNumber(), UNIXToolkit.isGtkVerbose());
++                nativeLibraryLoaded = false;
+             }
+         } finally {
+             initExecuted = true;
+@@ -75,7 +74,7 @@
+ 
+     static boolean isDesktopSupported() {
+         initWithLock();
+-        return nativeLibraryLoaded && !supportedActions.isEmpty();
++        return /*nativeLibraryLoaded &&*/ !supportedActions.isEmpty();
+     }
+ 
+     public boolean isSupported(Action type) {
+@@ -109,22 +108,19 @@
+     }
+ 
+     private void launch(URI uri) throws IOException {
+-        byte[] uriByteArray = ( uri.toString() + '\0' ).getBytes();
+         boolean result = false;
++        int ret = -1;
+         XToolkit.awtLock();
+         try {
+-            if (!nativeLibraryLoaded) {
+-                throw new IOException("Failed to load native libraries.");
+-            }
+-            result = gnome_url_show(uriByteArray);
++            ret = Runtime.getRuntime().exec(new String[] {"xdg-open", uri.toString()}).waitFor();
++            result = ret == 0;
++        } catch (InterruptedException e) {
++            System.err.println("Caught InterruptedException: " + e.getMessage());
+         } finally {
+             XToolkit.awtUnlock();
+         }
+         if (!result) {
+-            throw new IOException("Failed to show URI:" + uri);
++            throw new IOException("xdg-open failed with error code "+ ret +" for URI: " + uri);
+         }
+     }
+-
+-    private native boolean gnome_url_show(byte[] url);
+-    private static native boolean init(int gtkVersion, boolean verbose);
+ }

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -96,6 +96,9 @@ modules:
         path: 39020dd9b75f
       - type: patch
         path: 371bbe373ae0
+      - type: patch
+        # https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11/issues/15
+        path: java_desktop_xdg_open.patch
   - name: cacerts
     buildsystem: simple
     sources:


### PR DESCRIPTION
even when there's no GTK installed, by replacing
gnome_url_show() (which also may call gtk_show_uri())
by 'xdg-open' command, which will work in any desktop
and not only GTK/Gnome.

It will also work when using the minimal Freedesktop
runtime, which many Java apps are built upon.

https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11/issues/15