### PR TITLE
Update to runtime 22.08

### DIFF
--- a/extract_cacerts.sh
+++ b/extract_cacerts.sh
@@ -30,13 +30,28 @@ function get_alias() {
 	echo "$alias" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9()._-]//g'
 }
 
+declare -A used_aliases
+
 for certificate in $(ls /etc/ssl/certs/*.pem) ; do
 	cert=$($jdk/bin/keytool -printcert -file $certificate)
 	issuer=$(echo "$cert" | grep '^Issuer' | cut -d' ' -f1 --complement)
 	fprint=$(echo "$cert" | grep 'SHA1:' | cut -d' ' -f3)
 	alias=$(get_alias "$issuer")
+
+	# If this alias has already been used, add a unique digit to the end
+	if [[ -v "used_aliases[$alias]" ]]; then
+		original_alias="$alias"
+		for i in {1..9}; do
+			alias="${original_alias}$i"
+			[[ -v "used_aliases[$alias]" ]] || break
+		done
+
+		echo "Note: renaming duplicate alias $original_alias -> $alias" >&2
+	fi
+
 	echo "Adding $fprint ($alias)"
 	$jdk/bin/keytool -importcert -noprompt -alias $alias -storepass changeit -storetype JKS -keystore cacerts -file $certificate
+	used_aliases["$alias"]=1
 done
 
 rm $jdk/lib/security/cacerts

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -1,8 +1,8 @@
 ---
 id: org.freedesktop.Sdk.Extension.openjdk11
-branch: '21.08'
+branch: '22.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false


### PR DESCRIPTION
**ALERT: Maintainers make sure this is actually merged into a new branch/22.08, not the currently targeted 21.08!!!!**

<hr>

The extract_cacerts.sh changes here are needed because there are *two* certificates with CN="Autoridad de Certificacion Firmaprofesional CIF A62634068", thus the same alias ends up generated for both (the distinction is that one is an older SHA1withRSA certificate). In order to differentiate these, any certificates with a duplicate alias will have an increasing digit appended to the end of the name.

(In Fedora land, their certdata.txt does add a " 1" to the end of the CN, though it's not clear to me where that transformation takes place.)