### PR TITLE
Update 22.08 gradle to 8.2.1

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -127,9 +127,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.2.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: b586e04868a22fd817c8971330fec37e298f3242eb85c374181b12d637f80302
+        sha256: 03ec176d388f2aa99defcadc3ac6adf8dd2bce5145a129659537c0874dea5ad1
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle


### PR DESCRIPTION
Should we just update gradle? There could be breaking changes but in general gradle projects would use the wrapper & be independent from the system provided version.

As references: Fedora doesn't provide gradle at all & Arch Linux simply updates to the newest version.

An alternative would be to keep it as is in 22.08 & always update or completely drop it for 23.08.