### PR TITLE
Update 23.08 to 11.0.20.1+1 & modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -108,9 +108,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
+        sha512: deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -43,7 +43,7 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk11/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=7
+      - --with-version-build=1
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=18.9
@@ -72,11 +72,11 @@ modules:
       - CFLAGS_WARNINGS_ARE_ERRORS=-Wno-error
       - images
     post-install:
-      - (cd /usr/lib/sdk/openjdk11/jvm && ln -s openjdk-11.0.19 openjdk-11)
+      - (cd /usr/lib/sdk/openjdk11/jvm && ln -s openjdk-11.0.20.1 openjdk-11)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk11u/archive/refs/tags/jdk-11.0.19+7.tar.gz
-        sha512: 6858aac76becbebb5e35f7ec28f495187b262f5a8abd31eb84eb3a5ca4abfff6c373c502082eba55340776bc83dc134ca9005686f4a5004938e05f90210cdd8e
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk-sources_11.0.20.1_1.tar.gz
+        sha256: f97bdcc9732ae67c1a754fafd36b7870282fb424cf656e8f4c59215810beff38
       - type: shell
         commands:
           - chmod a+x configure

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -121,9 +121,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.3-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: b586e04868a22fd817c8971330fec37e298f3242eb85c374181b12d637f80302
+        sha256: 591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -25,18 +25,18 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-11.0.5.10-0.fc29.x86_64.tar.bz2
-        dest-filename: java-openjdk.tar.bz2
-        sha512: 65bbd1c7c5e37b578d9d8273dfeaeb367206b66dedc5ef46821d70ba19a2cf3b4189e3bdd9562bd55c0c1e2c008fe954066d5e425ba4e3b51c76f31a4fc61619
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20.1_1.tar.gz
+        dest-filename: java-openjdk.tar.gz
+        sha256: 398a64bff002f0e3b0c01ecd24a1a32c83cb72a5255344219e9757d4ddd9f857
       - type: file
         only-arches:
           - aarch64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-11.0.5.10-0.fc29.aarch64.tar.bz2
-        dest-filename: java-openjdk.tar.bz2
-        sha512: 36352df2104d50ac93d6279e121734657bcf85ffbab9593ece2342dbb12b8a7648fadc438be0b6e547d77010e249e89cf4ffc8be68372807d4c935c1a9addcfe
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20.1_1.tar.gz
+        dest-filename: java-openjdk.tar.gz
+        sha256: 69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
-      - tar xf java-openjdk.tar.bz2 --strip-components=4 --directory=$FLATPAK_DEST/bootstrap-java
+      - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
   - name: java
     buildsystem: autotools
     no-parallel-make: true

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -94,9 +94,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: de4ac604629e39a86a306f0541adb3775596909ad92feb8b7de759b1b286417db24f557228737c8b902d6abf722d2ce5bb0c3baa3640cbeec3481e15ab1958c9
+        sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
     build-commands:
       - mkdir -p $FLATPAK_DEST/ant
       - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant


### PR DESCRIPTION
@MatMaul, @hfiguiere
Would be great if someone could review the updates (here & for OpenJDK8 which requires branch/23.08, see flathub/org.freedesktop.Sdk.Extension.openjdk8#36).