### PR TITLE
Add x-checker-data for automatic update of the modules in 23.08

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.yaml]
+max_line_length = 1000

--- a/java-remove-version-build.patch
+++ b/java-remove-version-build.patch
@@ -1,0 +1,42 @@
+commit ddc5979007c950cfb24cc9793c62e33a5469fc90
+Author: Martin Pilarski <mpilarski@aqwe.de>
+Date:   Sun Jan 21 21:36:18 2024 +0100
+
+    Avoid unsetting of VERSION_BUILD by removing corresponding code.
+    VERSION_BUILD gets set via make/autoconf/version-numbers.
+
+diff --git a/make/autoconf/jdk-version.m4 b/make/autoconf/jdk-version.m4
+index f0d1edfcb..34bf155ea 100644
+--- a/make/autoconf/jdk-version.m4
++++ b/make/autoconf/jdk-version.m4
+@@ -253,30 +253,6 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
+     fi
+   fi
+ 
+-  AC_ARG_WITH(version-build, [AS_HELP_STRING([--with-version-build],
+-      [Set version 'BUILD' field (build number) @<:@not specified@:>@])],
+-      [with_version_build_present=true], [with_version_build_present=false])
+-
+-  if test "x$with_version_build_present" = xtrue; then
+-    if test "x$with_version_build" = xyes; then
+-      AC_MSG_ERROR([--with-version-build must have a value])
+-    elif test "x$with_version_build" = xno; then
+-      # Interpret --without-* as empty string instead of the literal "no"
+-      VERSION_BUILD=
+-    elif test "x$with_version_build" = x; then
+-      VERSION_BUILD=
+-    else
+-      JDKVER_CHECK_AND_SET_NUMBER(VERSION_BUILD, $with_version_build)
+-    fi
+-  else
+-    if test "x$NO_DEFAULT_VERSION_PARTS" != xtrue; then
+-      # Default is to not have a build number.
+-      VERSION_BUILD=""
+-      # FIXME: Until all code can cope with an empty VERSION_BUILD, set it to 0.
+-      VERSION_BUILD=0
+-    fi
+-  fi
+-
+   AC_ARG_WITH(version-feature, [AS_HELP_STRING([--with-version-feature],
+       [Set version 'FEATURE' field (first number) @<:@current source value@:>@])],
+       [with_version_feature_present=true], [with_version_feature_present=false])

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -1,4 +1,3 @@
----
 id: org.freedesktop.Sdk.Extension.openjdk11
 branch: '23.08'
 runtime: org.freedesktop.Sdk
@@ -43,7 +42,6 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk11/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=1
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=18.9
@@ -74,12 +72,21 @@ modules:
     post-install:
       - (cd /usr/lib/sdk/openjdk11/jvm && ln -s openjdk-11.* openjdk-11)
     sources:
-      - type: archive
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21+9/OpenJDK11U-jdk-sources_11.0.21_9.tar.gz
-        sha256: 6ca74f1e409c2b038735a8f0a1764c0ca2d9f356d60629a3af8f66bfa1397791
+      - type: git
+        url: https://github.com/adoptium/jdk11u.git
+        tag: jdk-11.0.21+9
+        commit: a046767fe01a2d02ec81dcba2bd0a43e435dc709
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
+          is-main-source: true
+          tag-query: .tag_name
+      - type: patch
+        path: java-remove-version-build.patch
       - type: shell
         commands:
           - chmod a+x configure
+          - git describe --match jdk-11.*+* HEAD | sed -e 's/jdk-11.*+\(\)/VERSION_BUILD=\1/' >> make/autoconf/version-numbers
   - name: cacerts
     buildsystem: simple
     sources:
@@ -97,6 +104,12 @@ modules:
         url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
         sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
+        x-checker-data:
+          type: anitya
+          project-id: 50
+          stable-only: true
+          is-main-source: false
+          url-template: http://archive.apache.org/dist/ant/binaries/apache-ant-$version-bin.tar.gz
     build-commands:
       - mkdir -p $FLATPAK_DEST/ant
       - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant
@@ -111,6 +124,14 @@ modules:
         url: http://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
         sha512: deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          is-main-source: false
+          url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
+          versions:
+            <: 4.0.0
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
@@ -124,6 +145,12 @@ modules:
         url: https://services.gradle.org/distributions/gradle-8.3-bin.zip
         dest-filename: gradle-bin.zip
         sha256: 591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
+        x-checker-data:
+          type: json
+          url: https://services.gradle.org/versions/current
+          is-main-source: false
+          version-query: .version
+          url-query: .downloadUrl
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle


### PR DESCRIPTION
Remove the config-option (--with-version-build) which can't be set by flatpak-external-data-checker. Instead, generate the missing version-build via a bash command & write it into
make/autoconf/version-numbers to automatically pick the current version at build time. The source was switchted to the git repository to access the tag. Most likely the tag format will not change in a future release.

Because VERSION_BUILD will be overridden when build & not provided as config-option, the corresponding code is removed via a patch.

Add .editorconfig to avoid line splitting on manifest update.