### PR TITLE
 Add Flathub's external data checker for the JDK (and update it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension contains the OpenJDK 11 Java Runtime Environment (JRE) and Java D
 
 OpenJDK 11 is the previous long-term support (LTS) version.
 
-For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
+For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
 
 For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -23,9 +23,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20.1_1.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.24_8.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 398a64bff002f0e3b0c01ecd24a1a32c83cb72a5255344219e9757d4ddd9f857
+        sha256: 0e71a01563a5c7b9988a168b0c4ce720a6dff966b3c27bb29d1ded461ff71d0e
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -34,9 +34,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20.1_1.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.24_8.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672
+        sha256: 04e21301fedc76841fb03929ac6cacfbbda30b5693acfd515a8f34d4a0cdeb28
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -26,12 +26,22 @@ modules:
         url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20.1_1.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 398a64bff002f0e3b0c01ecd24a1a32c83cb72a5255344219e9757d4ddd9f857
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name | startswith("OpenJDK11U-jdk_x64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
       - type: file
         only-arches:
           - aarch64
         url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20.1_1.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name | startswith("OpenJDK11U-jdk_aarch64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java


### PR DESCRIPTION
... And also update the README to mention that OpenJDK 21 is the current LTS version (available on Flathub).