### PR TITLE
[branch/23.08] Update bootstrap_jdk and java modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.24_8.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.25%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 0e71a01563a5c7b9988a168b0c4ce720a6dff966b3c27bb29d1ded461ff71d0e
+        sha256: 191baa2e052627614022171400a917d28f0987dc54da48aaf07b06f552bb9884
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -35,9 +35,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.24_8.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.25%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.25_9.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 04e21301fedc76841fb03929ac6cacfbbda30b5693acfd515a8f34d4a0cdeb28
+        sha256: f2087cc3abdd509b74facf8e43e81e36244d14c70dec080b8f3a662695417ca7
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -84,8 +84,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk11u.git
-        tag: jdk-11.0.24+8
-        commit: ff537af466ee74e914c5cee1042de650bfe0da5f
+        tag: jdk-11.0.25+9
+        commit: cee8535a9d3de8558b4b5028d68e397e508bef71
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest


### PR DESCRIPTION
bootstrap_jdk: Update java-openjdk.tar.gz to jdk-11.0.25+9
java: Update jdk11u.git

(cherry picked from commit 9bea54b9193df4172b91e438df4978095550b74b)