### PR TITLE
[branch/23.08] Update bootstrap_jdk, java, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.27_6.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.28_6.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: dc6136eaa8c1898cbf8973bb1e203e1f653f4c9166be0f5bebe0b02c5f3b5ae3
+        sha256: 7dfd551795a8884b26cbb02e0301da95db40160bb194f48271dc2ef9367f50c2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -35,9 +35,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.27%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.27_6.tar.gz
+        url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.28_6.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 4decd2e5caf4667144091cf723458b14148dc990730b3ecb34bba5eb1aa4ad5d
+        sha256: 32c316cb3998a9c9dee2829fbb577ea1c0ed666700cec73e049d44c342bb19af
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -84,8 +84,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk11u.git
-        tag: jdk-11.0.27+6
-        commit: 856bab316a63ce3acddd08d3fbe76b9c3223cdb6
+        tag: jdk-11.0.28+6
+        commit: 141d7af9cd3c41de974c3d3f8017d6b21dc6d36c
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -134,9 +134,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -155,9 +155,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.13-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.14.3-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+        sha256: bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
         x-checker-data:
           type: json
           url: https://services.gradle.org/versions/current


### PR DESCRIPTION
bootstrap_jdk: Update java-openjdk.tar.gz to jdk-11.0.28+6
java: Update jdk11u.git
maven: Update apache-maven-bin.tar.gz to 3.9.11
gradle: Update gradle-bin.zip to 8.14.3

(cherry picked from commit 19e0d6c823fc2ba76e93ff9b92b2d2d3ad0f2cf5)