### PR TITLE
[branch/25.08] Update runtime to 25.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
 ```yaml
 app-id: com.example.myapp
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk11

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Sdk.Extension.openjdk11
-branch: '24.08'
+branch: '25.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
@@ -67,7 +67,7 @@ modules:
       - --with-harfbuzz=system
       - --with-stdc++lib=dynamic
       - --with-extra-cxxflags=-O2 -g -Wno-error -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse
-      - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fpermissive
+      - --with-extra-cflags=-O2 -g -std=gnu99 -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fpermissive
       - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now
       - --with-jvm-features=shenandoahgc
       - --disable-javac-server
@@ -95,6 +95,7 @@ modules:
           - patches/java-remove-version-build.patch
           - patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
           - patches/0002-ConfigureNotify-behavior-has-changed-in-KWin-6.2.patch
+          - patches/0003-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
       - type: shell
         commands:
           - chmod a+x configure

--- a/patches/0003-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
+++ b/patches/0003-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
@@ -1,0 +1,116 @@
+diff --git a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+index 8047ed8fd2..aece16763a 100644
+--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+@@ -1702,7 +1702,7 @@ void Assembler::add_sub_immediate(Register Rd, Register Rn, unsigned uimm, int o
+ }
+ 
+ bool Assembler::operand_valid_for_add_sub_immediate(int64_t imm) {
+-  uint64_t uimm = (uint64_t)uabs((jlong)imm);
++  uint64_t uimm = (uint64_t)g_uabs((jlong)imm);
+   if (uimm < (1 << 12))
+     return true;
+   if (uimm < (1 << 24)
+diff --git a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+index e07bbba3f6..be13d56034 100644
+--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
++++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+@@ -854,7 +854,7 @@ public:
+   static const uint64_t branch_range = NOT_DEBUG(128 * M) DEBUG_ONLY(2 * M);
+ 
+   static bool reachable_from_branch_at(address branch, address target) {
+-    return uabs(target - branch) < branch_range;
++    return g_uabs(target - branch) < branch_range;
+   }
+ 
+   // Unconditional branch (immediate)
+diff --git a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+index 7f329a45d3..c280df9f72 100644
+--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+@@ -2206,7 +2206,7 @@ void MacroAssembler::wrap_add_sub_imm_insn(Register Rd, Register Rn, unsigned im
+   if (operand_valid_for_add_sub_immediate((int)imm)) {
+     (this->*insn1)(Rd, Rn, imm);
+   } else {
+-    if (uabs(imm) < (1 << 24)) {
++    if (g_uabs(imm) < (1 << 24)) {
+        (this->*insn1)(Rd, Rn, imm & -(1 << 12));
+        (this->*insn1)(Rd, Rd, imm & ((1 << 12)-1));
+     } else {
+diff --git a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+index 598a25969d..31817702b6 100644
+--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+@@ -1009,7 +1009,7 @@ class StubGenerator: public StubCodeGenerator {
+ 
+   void copy_memory_small(Register s, Register d, Register count, Register tmp, int step) {
+     bool is_backwards = step < 0;
+-    size_t granularity = uabs(step);
++    size_t granularity = g_uabs(step);
+     int direction = is_backwards ? -1 : 1;
+     int unit = wordSize * direction;
+ 
+@@ -1065,7 +1065,7 @@ class StubGenerator: public StubCodeGenerator {
+                    Register count, Register tmp, int step) {
+     copy_direction direction = step < 0 ? copy_backwards : copy_forwards;
+     bool is_backwards = step < 0;
+-    unsigned int granularity = uabs(step);
++    unsigned int granularity = g_uabs(step);
+     const Register t0 = r3, t1 = r4;
+ 
+     // <= 80 (or 96 for SIMD) bytes do inline. Direction doesn't matter because we always
+diff --git a/src/hotspot/share/opto/mulnode.cpp b/src/hotspot/share/opto/mulnode.cpp
+index 6616fa0ad0..78cd34490d 100644
+--- a/src/hotspot/share/opto/mulnode.cpp
++++ b/src/hotspot/share/opto/mulnode.cpp
+@@ -194,7 +194,7 @@ Node *MulINode::Ideal(PhaseGVN *phase, bool can_reshape) {
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+ 
+-  unsigned int abs_con = uabs(con);
++  unsigned int abs_con = g_uabs(con);
+   if (abs_con != (unsigned int)con) {
+     sign_flip = true;
+   }
+@@ -290,7 +290,7 @@ Node *MulLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+ 
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+-  julong abs_con = uabs(con);
++  julong abs_con = g_uabs(con);
+   if (abs_con != (julong)con) {
+     sign_flip = true;
+   }
+diff --git a/src/hotspot/share/utilities/globalDefinitions.hpp b/src/hotspot/share/utilities/globalDefinitions.hpp
+index c758fc5743..581753769d 100644
+--- a/src/hotspot/share/utilities/globalDefinitions.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions.hpp
+@@ -1166,7 +1166,7 @@ inline bool is_even(intx x) { return !is_odd(x); }
+ 
+ // abs methods which cannot overflow and so are well-defined across
+ // the entire domain of integer types.
+-static inline unsigned int uabs(unsigned int n) {
++static inline unsigned int g_uabs(unsigned int n) {
+   union {
+     unsigned int result;
+     int value;
+@@ -1175,7 +1175,7 @@ static inline unsigned int uabs(unsigned int n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(julong n) {
++static inline julong g_uabs(julong n) {
+   union {
+     julong result;
+     jlong value;
+@@ -1184,8 +1184,8 @@ static inline julong uabs(julong n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(jlong n) { return uabs((julong)n); }
+-static inline unsigned int uabs(int n) { return uabs((unsigned int)n); }
++static inline julong g_uabs(jlong n) { return g_uabs((julong)n); }
++static inline unsigned int g_uabs(int n) { return g_uabs((unsigned int)n); }
+ 
+ // "to" should be greater than "from."
+ inline intx byte_size(void* from, void* to) {


### PR DESCRIPTION
This also imports [an upstream patch](https://github.com/adoptium/jdk/commit/38bb8adf4f632b08af15f2d8530b35f05f86a020) (backported) to fix a build failure with glibc >= 2.42:

```
/usr/lib/gcc/x86_64-unknown-linux-gnu/15.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /usr/lib/gcc/x86_64-unknown-linux-gnu/15.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /run/build/java/build/linux-x86_64-normal-server-release/hotspot/variant-server/libjvm/objs/abstractInterpreter.o: in function `uabs': /run/build/java/src/hotspot/share/utilities/globalDefinitions.hpp:1175: multiple definition of `uabs'; /run/build/java/build/linux-x86_64-normal-server-release/hotspot/variant-server/libjvm/objs/abstractCompiler.o:/run/build/java/src/hotspot/share/utilities/globalDefinitions.hpp:1175: first defined here /usr/lib/gcc/x86_64-unknown-linux-gnu/15.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: collect2: fatal error: ld terminated with signal 15 [Terminated] compilation terminated.
```

This also adds a build flag to set the C standard to GNU99, to fix at least one build error (but there are probably much more):

```
/run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c: In function 'getProxyByGProxyResolver': /run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c:389:16: error: too many arguments to function 'g_proxy_resolver_lookup'; expected 0, have 4
  389 |     proxies = (*g_proxy_resolver_lookup)(resolver, uri, NULL, &error);
      |               ~^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
/run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c:408:34: error: too many arguments to function 'g_network_address_parse_uri'; expected 0, have 3
  408 |                                 (*g_network_address_parse_uri)(proxies[i], 0,
      |                                 ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~
/run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c:413:38: error: too many arguments to function 'g_network_address_get_hostname'; expected 0, have 1
  413 |                             phost = (*g_network_address_get_hostname)(conn);
      |                                     ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~
/run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c:414:38: error: too many arguments to function 'g_network_address_get_port'; expected 0, have 1
  414 |                             pport = (*g_network_address_get_port)(conn);
      |                                     ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~
/run/build/java/src/java.base/unix/native/libnet/DefaultProxySelector.c:450:10: error: too many arguments to function 'g_strfreev'; expected 0, have 1
  450 |         (*g_strfreev)(proxies);
      |         ~^~~~~~~~~~~~ ~~~~~~~
```