### PR TITLE
[branch/24.08] Update java, maven and gradle modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension contains the OpenJDK 11 Java Runtime Environment (JRE) and Java D
 
 OpenJDK 11 is the previous long-term support (LTS) version.
 
-For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
+For the current LTS version, see the [OpenJDK 25](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk25) extension.
 
 For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -5,16 +5,20 @@ runtime-version: '24.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
+
 cleanup:
   - /share/info
   - /share/man
+
 build-options:
   no-debuginfo: true
   strip: true
   prefix: /usr/lib/sdk/openjdk11
   env:
     V: '1'
+
 modules:
+  # Boot JDK requirements: https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk/master/doc/building.html#boot-jdk-requirements
   - name: bootstrap_jdk
     buildsystem: simple
     cleanup:
@@ -45,6 +49,7 @@ modules:
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
+
   - name: java
     buildsystem: autotools
     no-parallel-make: true
@@ -99,6 +104,7 @@ modules:
         commands:
           - chmod a+x configure
           - git describe --match jdk-11.*+* HEAD | sed -e 's/jdk-11.*+\(\)/VERSION_BUILD=\1/' >> make/autoconf/version-numbers
+
   - name: cacerts
     buildsystem: simple
     sources:
@@ -106,6 +112,8 @@ modules:
         path: extract_cacerts.sh
     build-commands:
       - ./extract_cacerts.sh /usr/lib/sdk/openjdk11/jvm/openjdk-11
+
+  # Java version requirements for Ant: https://ant.apache.org/faq.html#java-version
   - name: ant
     buildsystem: simple
     cleanup:
@@ -126,6 +134,8 @@ modules:
       - mkdir -p $FLATPAK_DEST/ant
       - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant
       - ln -s $FLATPAK_DEST/ant/bin/ant $FLATPAK_DEST/bin
+
+  # Java version requirements for Maven: https://maven.apache.org/docs/history.html
   - name: maven
     buildsystem: simple
     cleanup:
@@ -149,6 +159,7 @@ modules:
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
       - ln -s $FLATPAK_DEST/maven/bin/mvn $FLATPAK_DEST/maven/bin/mvnDebug $FLATPAK_DEST/bin
 
+  # Java version requirements for Gradle: https://docs.gradle.org/current/userguide/compatibility.html#java_runtime
   - name: gradle
     buildsystem: simple
     cleanup:
@@ -164,12 +175,12 @@ modules:
           stable-only: true
           url-template: https://services.gradle.org/distributions/gradle-$version-bin.zip
           versions:
-            <: '9' # https://docs.gradle.org/current/userguide/compatibility.html#java_runtime
-
+            <: '9'
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle
       - ln -s $FLATPAK_DEST/gradle/bin/gradle $FLATPAK_DEST/bin
+
   - name: scripts
     buildsystem: simple
     sources:
@@ -194,6 +205,7 @@ modules:
         dest-filename: enable.sh
     build-commands:
       - cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk11/
+
   - name: appdata
     buildsystem: simple
     sources:

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -78,8 +78,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk11u.git
-        tag: jdk-11.0.29+7
-        commit: d3b1c2be9e87aad07cac29d94679130fe5807c17
+        tag: jdk-11.0.30+7
+        commit: 5d80a0e0571e163077356904d7810fcc8d9b26f0
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -133,9 +133,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
+        sha512: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -156,9 +156,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.14.4-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
+        sha256: f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
         x-checker-data:
           type: anitya
           project-id: 6088

--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -30,22 +30,12 @@ modules:
         url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.29_7.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 3c8f2b53dd137cd86e54f40df96fd0fc56df72c749c06469e7eab216503bc7cf
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name | startswith("OpenJDK11U-jdk_x64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
       - type: file
         only-arches:
           - aarch64
         url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.29_7.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 71e00cd0ab4371a4e9d67d1a2ca3e8ed2f126dff6a6ab152a6ecdec60100fbdd
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name | startswith("OpenJDK11U-jdk_aarch64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java


### PR DESCRIPTION
Changes:

- readme: OpenJDK 25 is the current LTS version
- manifest: Add some useful documentation links
- Remove f-e-d-c for Boot JDK
- java: Update jdk11u.git to jdk-11.0.30+7
- maven: Update apache-maven-bin.tar.gz to 3.9.12
- gradle: Update gradle-bin.zip to 8.14.4