### PR TITLE
[branch/24.08] Update java, ant and maven modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -78,8 +78,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk11u.git
-        tag: jdk-11.0.30+7
-        commit: 5d80a0e0571e163077356904d7810fcc8d9b26f0
+        tag: jdk-11.0.31+11
+        commit: 5060e1b41c44f98fb01e49c9b415d3187fdd0bd9
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -111,9 +111,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.17-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: d78427aff207592c024ff1552dc04f7b57065a195c42d398fcffe7a0145e8d00cd46786f5aa52e77ab0fdf81334f065eb8011eecd2b48f7228e97ff4cb20d16c
+        sha512: a96ca6455ec9af5e702df7d1ed5a2ec1cfb381eac3e9a767ecb6be1706e826941045e8fd7ca663ba101bc47bfa18351f540dd27e9e7af57908ac78e65268eee7
         x-checker-data:
           type: anitya
           project-id: 50
@@ -133,9 +133,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
+        sha512: 33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
         x-checker-data:
           type: anitya
           project-id: 1894


### PR DESCRIPTION
java: Update jdk11u.git to jdk-11.0.31+11
ant: Update apache-ant-bin.tar.gz to 1.10.17
maven: Update apache-maven-bin.tar.gz to 3.9.15

(cherry picked from commit 9208d7562b78c8a9c426988e80e98acd20105912)