### PR TITLE
[branch/24.08] Update java, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk11.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk11.yaml
@@ -78,8 +78,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk11u.git
-        tag: jdk-11.0.31+11
-        commit: 5060e1b41c44f98fb01e49c9b415d3187fdd0bd9
+        tag: jdk-11.0.32-ga
+        commit: f67076179e1cd0db7a2bf291e6dfcf14c3bdaf2d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest
@@ -133,9 +133,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
+        sha512: 831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -156,9 +156,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.14.5-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
+        sha256: 6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
         x-checker-data:
           type: anitya
           project-id: 6088


### PR DESCRIPTION
java: Update jdk11u.git to jdk-11.0.32-ga
maven: Update apache-maven-bin.tar.gz to 3.9.16
gradle: Update gradle-bin.zip to 8.14.5

(cherry picked from commit c369ff8eb33c0b96b37ee64c95f776f9df68f9ec)